### PR TITLE
경험치 증가 기능

### DIFF
--- a/src/main/java/com/everybox/everybox/domain/User.java
+++ b/src/main/java/com/everybox/everybox/domain/User.java
@@ -27,4 +27,11 @@ public class User {
 
     @Column(unique = true, nullable = true)
     private String universityEmail;
+
+    @Builder.Default
+    private Long experience = 0L;
+
+    public void gainExperience(long amount) {
+        this.experience += amount;
+    }
 }

--- a/src/main/java/com/everybox/everybox/domain/User.java
+++ b/src/main/java/com/everybox/everybox/domain/User.java
@@ -31,7 +31,15 @@ public class User {
     @Builder.Default
     private Long experience = 0L;
 
+    @Builder.Default
+    private Long level = 1L;
+
     public void gainExperience(long amount) {
         this.experience += amount;
+
+        while (this.experience >= level * 100) {
+            this.experience %= 100;
+            this.level++;
+        }
     }
 }

--- a/src/main/java/com/everybox/everybox/experience/ExpType.java
+++ b/src/main/java/com/everybox/everybox/experience/ExpType.java
@@ -1,0 +1,17 @@
+package com.everybox.everybox.experience;
+
+import lombok.Getter;
+
+@Getter
+public enum ExpType {
+    CREATE_POST(10L, "음식 등록하기"),
+    START_CHAT(30L, "채팅 시작하기");
+
+    private final long exp;
+    private final String description;
+
+    ExpType(long exp, String description) {
+        this.exp = exp;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/everybox/everybox/experience/GainExp.java
+++ b/src/main/java/com/everybox/everybox/experience/GainExp.java
@@ -1,0 +1,14 @@
+package com.everybox.everybox.experience;
+
+import com.everybox.everybox.experience.ExpType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GainExp {
+    ExpType value();
+}

--- a/src/main/java/com/everybox/everybox/experience/GainExpAspect.java
+++ b/src/main/java/com/everybox/everybox/experience/GainExpAspect.java
@@ -1,0 +1,47 @@
+package com.everybox.everybox.experience;
+
+import com.everybox.everybox.domain.User;
+import com.everybox.everybox.experience.ExpType;
+import com.everybox.everybox.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GainExpAspect {
+
+    private final UserRepository userRepository;
+
+    @Around("@annotation(gainExp)")
+    public Object handleExperience(ProceedingJoinPoint joinPoint, GainExp gainExp) throws Throwable {
+        Object result = joinPoint.proceed(); // 원래 메서드 실행
+
+        // 유저 ID를 파라미터에서 찾는다 (Long userId)
+        Long userId = Arrays.stream(joinPoint.getArgs())
+                .filter(arg -> arg instanceof Long)
+                .map(arg -> (Long) arg)
+                .findFirst()
+                .orElse(null);
+
+        if (userId != null) {
+            User user = userRepository.findById(userId).orElseThrow();
+            ExpType expType = gainExp.value(); // 전달받은 타입 확인
+
+            // 경험치 증가
+            user.gainExperience(expType.getExp());
+            userRepository.save(user);
+            log.info("사용자 {} : '{}' 완료, 경험치 {} xp 획득", userId, expType.getDescription(), expType.getExp());
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/everybox/everybox/service/ChatService.java
+++ b/src/main/java/com/everybox/everybox/service/ChatService.java
@@ -3,6 +3,8 @@ package com.everybox.everybox.service;
 import com.everybox.everybox.domain.*;
 import com.everybox.everybox.dto.MessageDto;
 import com.everybox.everybox.dto.MessageSendRequestDto;
+import com.everybox.everybox.experience.ExpType;
+import com.everybox.everybox.experience.GainExp;
 import com.everybox.everybox.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ public class ChatService {
     private final MessageRepository messageRepository;
 
     // 1:1 쌍당 1개만!
+    @GainExp(ExpType.START_CHAT)
     public ChatRoom createOrGetChatRoom(Long senderId, Long receiverId, Long postId) {
         ChatRoom existingRoom = chatRoomRepository.findBySenderIdAndReceiverIdAndPostId(senderId, receiverId, postId);
         if (existingRoom != null) return existingRoom;

--- a/src/main/java/com/everybox/everybox/service/PostService.java
+++ b/src/main/java/com/everybox/everybox/service/PostService.java
@@ -3,6 +3,8 @@ package com.everybox.everybox.service;
 import com.everybox.everybox.domain.Post;
 import com.everybox.everybox.domain.User;
 import com.everybox.everybox.dto.PostUpdateRequestDto;
+import com.everybox.everybox.experience.ExpType;
+import com.everybox.everybox.experience.GainExp;
 import com.everybox.everybox.repository.PostRepository;
 import com.everybox.everybox.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
+    @GainExp(ExpType.CREATE_POST)
     public Post createPost(String title, String details, String location, int quantity, String imageUrl, Long userId) {
         User giver = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));


### PR DESCRIPTION
## 📝 기능 설명
- 새로운 음식(새로운 글) 등록 -> 경험치 10xp 증가
- 채팅방 생성 -> 경험치 30xp 증가

경험치 100xp 달성 시에 레벨을 증가하도록 하였습니다.

## 🛠 작업 사항
User에 experience 필드 추가하여 우선 두가지 행동에 대해서 경험치가 상승하도록 GainExp 어노테이션을 구현하였습니다.
userId를 인자로 갖고 있는 함수의 경우에 어노테이션을 달아서 경험치를 증가시킬 수 있습니다

## ✅ 작업 체크리스트
- [x] userId를 인자로 받는 함수의 경우 경험치 증가
- [x]  특정 경험치 달성시 레벨 증가

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
